### PR TITLE
Feature #149 - Delete method to make user inactive was created

### DIFF
--- a/beauty/api/permissions.py
+++ b/beauty/api/permissions.py
@@ -76,3 +76,20 @@ class IsPositionOwner(permissions.BasePermission):
             return obj.business.owner == request.user
         else:
             return False
+
+
+class IsProfileOwner(permissions.BasePermission):
+    """Permission used in Users profile."""
+
+    def has_object_permission(self, request, view, obj):
+        """User Profile permission.
+
+        Object-level permission to only allow users of an object to edit it, still
+        it allows to view an object for non-users.
+        """
+        logger.info(f"{request.user} (id={request.user.id}) tried to access "
+                    f"object {obj.id}, permission is checked")
+
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return request.user.is_authenticated and (request.user.is_admin or obj == request.user)

--- a/beauty/api/permissions.py
+++ b/beauty/api/permissions.py
@@ -78,7 +78,7 @@ class IsPositionOwner(permissions.BasePermission):
             return False
 
 
-class IsProfileOwner(permissions.BasePermission):
+class IsProfileOwner(permissions.IsAuthenticated):
     """Permission used in Users profile."""
 
     def has_object_permission(self, request, view, obj):
@@ -92,4 +92,4 @@ class IsProfileOwner(permissions.BasePermission):
 
         if request.method in permissions.SAFE_METHODS:
             return True
-        return request.user.is_authenticated and (request.user.is_admin or obj == request.user)
+        return request.user.is_admin or obj == request.user

--- a/beauty/api/tests/test_DELETE_method_to_make_user_inactive.py
+++ b/beauty/api/tests/test_DELETE_method_to_make_user_inactive.py
@@ -1,0 +1,78 @@
+"""This module is for testing DELETE method that is used to inactivate Users.
+
+It tests perform_destroy method of CustomUserDetailRUDView.
+
+Tests:
+    *   Test that user can inactivate account
+    *   Test that user can't inactivate other user's accounts
+    *   Test that unauthorized users can't inactivate other user's accounts
+    *   Test that can't make himself inactive if he is already deactivated
+
+"""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework.reverse import reverse
+from api.models import CustomUser
+from .factories import CustomUserFactory
+
+
+class TestDeleteUser(TestCase):
+    """This class represents a Test case for the making User inactive.
+
+    All the neaded information is submited in the setUp method.
+    """
+
+    def setUp(self) -> None:
+        """This method adds needed info for tests."""
+        self.user1 = CustomUserFactory.create(is_active=True)
+        self.user2 = CustomUserFactory.create(is_active=True)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user1)
+
+    def test_delete_user(self):
+        """User can make himself inactive."""
+        response = self.client.delete(
+            path=reverse("api:user-detail", kwargs={"pk": self.user1.id}),
+            data={},
+        )
+        self.assertEquals(
+            [response.status_code, CustomUser.objects.get(pk=1).is_active],
+            [200, False],
+        )
+
+    def test_delete_user_wronguser(self):
+        """User can't make other users inactive."""
+        response = self.client.delete(
+            path=reverse("api:user-detail", kwargs={"pk": self.user2.id}),
+            data={},
+        )
+        self.assertEquals(
+            [response.status_code, CustomUser.objects.get(pk=2).is_active],
+            [403, True],
+        )
+
+    def test_delete_user_unauthorized(self):
+        """Unauthorized person can't make other users inactive."""
+        self.client.force_authenticate(user=None)
+        response = self.client.delete(
+            path=reverse("api:user-detail", kwargs={"pk": self.user1.id}),
+            data={},
+        )
+        self.assertEquals(
+            [response.status_code, CustomUser.objects.get(pk=1).is_active],
+            [401, True],
+        )
+
+    def test_delete_user_already_inactive(self):
+        """User can't make himself inactive if he is already deactivated."""
+        self.user1.is_active = False
+        self.user1.save()
+        response = self.client.delete(
+            path=reverse("api:user-detail", kwargs={"pk": self.user1.id}),
+            data={},
+        )
+        self.assertEquals(
+            [response.status_code, CustomUser.objects.get(pk=1).is_active],
+            [400, False],
+        )

--- a/beauty/api/views.py
+++ b/beauty/api/views.py
@@ -14,6 +14,9 @@ from rest_framework.generics import (GenericAPIView, ListCreateAPIView, Retrieve
 from rest_framework.permissions import (IsAuthenticated, IsAuthenticatedOrReadOnly)
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
+from rest_framework.decorators import action
+
+from djoser.views import UserViewSet as DjoserUserViewSet
 
 from beauty import signals
 from beauty.tokens import OrderApprovingTokenGenerator
@@ -358,3 +361,12 @@ class ServiceUpdateView(RetrieveUpdateDestroyAPIView):
     serializer_class = ServiceSerializer
 
     logger.debug("A view for retrieving, updating or deleting a service instance.")
+
+
+class UserViewSet(DjoserUserViewSet):
+    """This class is implemented to disable djoser DELETE method."""
+
+    @action(["get", "put", "patch"], detail=False)
+    def me(self, request, *args, **kwargs):
+        """Delete is now forbidden for this method."""
+        return super().me(request, *args, **kwargs)

--- a/beauty/beauty/urls.py
+++ b/beauty/beauty/urls.py
@@ -23,9 +23,10 @@ from django.urls import include, path
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
+from rest_framework.routers import DefaultRouter
 from beauty.yasg import urlpatterns as doc_urls
 
-from api.views import ResetPasswordView, UserActivationView
+from api.views import (ResetPasswordView, UserActivationView, UserViewSet)
 
 
 @api_view(["GET"])
@@ -50,6 +51,9 @@ def api_root(request, reverse_format=None):
     )
 
 
+router = DefaultRouter()
+router.register("auth/users", UserViewSet)
+
 urlpatterns = [
     path("", api_root),
     path("admin/", admin.site.urls),
@@ -64,15 +68,10 @@ urlpatterns = [
         name="reset-password",
     ),
     path("api/v1/", include("api.urls", namespace="api")),
-    # path(
-    #    "api-auth/",
-    # include("rest_framework.urls", namespace="rest_framework")
-    # ),
-    path(r"auth/", include("djoser.urls")),
     path(r"auth/", include("djoser.urls.jwt")),
-
 ]
 
+urlpatterns += router.urls
 urlpatterns += doc_urls
 
 if settings.DEBUG:


### PR DESCRIPTION
DELETE method now makes User inactive in all possible scenarios. Tests were written to ensure that. As we only make users inactive, rather than actually deleting them, djoser's delete method was disabled as redundant.

Closes #149, #151, #153