### PR TITLE
Fix #170 - User can't create review for a non specialist

### DIFF
--- a/beauty/api/serializers/review_serializers.py
+++ b/beauty/api/serializers/review_serializers.py
@@ -29,12 +29,12 @@ class ReviewAddSerializer(serializers.ModelSerializer):
         if reviewer == reviewee:
             logger.info(f"User {reviewer} (id = {reviewer.id}) tried reviewing himself or herself.")
             raise serializers.ValidationError(
-                {"error": "You are not able to review yourself"},
+                {"error": "You are not able to review yourself."},
             )
         if not reviewee.is_specialist:
             logger.info(f"User {reviewer} (id = {reviewer.id}) tried reviewing a non "
                         f"specialist user {reviewee} (id = {reviewee.id}).")
             raise serializers.ValidationError(
-                {"error": "You are not able to review yourself"},
+                {"error": "You are not able to review a nonspecialist."},
             )
         return super().save(**kwargs)

--- a/beauty/api/serializers/review_serializers.py
+++ b/beauty/api/serializers/review_serializers.py
@@ -11,9 +11,6 @@ logger = logging.getLogger(__name__)
 class ReviewAddSerializer(serializers.ModelSerializer):
     """This is a serializer for creating a Review."""
 
-    text_body = serializers.CharField(max_length=500)
-    rating = serializers.IntegerField(min_value=0, max_value=5)
-
     class Meta:
         """This is a class Meta that keeps settings for serializer."""
 
@@ -21,13 +18,23 @@ class ReviewAddSerializer(serializers.ModelSerializer):
         fields = ["text_body", "rating", "from_user", "to_user"]
 
     def save(self, **kwargs):
-        """The save method was redefined in order to check whether users
-        are trying to review themselves, which is not allowed.
+        """Method for saving reviews.
+
+        The save method was redefined in order to check whether users
+        are trying to review themselves, which is not allowed. It also
+        checks that users are not trying to review a non specialists.
         """
-        if kwargs["from_user"] == kwargs["to_user"]:
-            user = kwargs["from_user"]
-            logger.info(f"User {user} (id = {user.id}) tried reviewing himself.")
+        reviewer = kwargs["from_user"]
+        reviewee = kwargs["to_user"]
+        if reviewer == reviewee:
+            logger.info(f"User {reviewer} (id = {reviewer.id}) tried reviewing himself or herself.")
             raise serializers.ValidationError(
-                {"error": "You are not able to review yourself"}
+                {"error": "You are not able to review yourself"},
+            )
+        if not reviewee.is_specialist:
+            logger.info(f"User {reviewer} (id = {reviewer.id}) tried reviewing a non "
+                        f"specialist user {reviewee} (id = {reviewee.id}).")
+            raise serializers.ValidationError(
+                {"error": "You are not able to review yourself"},
             )
         return super().save(**kwargs)

--- a/beauty/api/tests/test_POST_method_to_add_review.py
+++ b/beauty/api/tests/test_POST_method_to_add_review.py
@@ -18,7 +18,7 @@ from django.test import TestCase
 from rest_framework.test import APIClient
 from rest_framework.reverse import reverse
 from api.serializers.review_serializers import ReviewAddSerializer
-from api.views import ReviewAddView
+from api.views_api import ReviewAddView
 from .factories import (CustomUserFactory,
                         GroupFactory,
                         ReviewFactory)

--- a/beauty/api/tests/test_POST_method_to_add_review.py
+++ b/beauty/api/tests/test_POST_method_to_add_review.py
@@ -20,8 +20,8 @@ from rest_framework.reverse import reverse
 from api.serializers.review_serializers import ReviewAddSerializer
 from api.views import ReviewAddView
 from .factories import (CustomUserFactory,
-                        ReviewFactory,
-                        GroupFactory)
+                        GroupFactory,
+                        ReviewFactory)
 
 
 class TestReviewAddView(TestCase):


### PR DESCRIPTION
- User can't create review for a non specialist (checked in serializer)
- Added test for that
- Adjusted previous tests