### PR TITLE
Feature #162 - Created email verification for adding to Position

### DIFF
--- a/beauty/api/admin.py
+++ b/beauty/api/admin.py
@@ -1,6 +1,6 @@
 """Configuration for admin."""
 
-from api.models import CustomUser, Order, Service, Position, Business, Review, Invitation
+from api.models import (CustomUser, Order, Service, Position, Business, Review, Invitation)
 from django.contrib import admin
 from django.contrib.auth.models import Group
 from django.contrib.auth.admin import (UserAdmin as BaseUserAdmin,

--- a/beauty/api/admin.py
+++ b/beauty/api/admin.py
@@ -1,6 +1,6 @@
 """Configuration for admin."""
 
-from api.models import CustomUser, Order, Service, Position, Business, Review
+from api.models import CustomUser, Order, Service, Position, Business, Review, Invitation
 from django.contrib import admin
 from django.contrib.auth.models import Group
 from django.contrib.auth.admin import (UserAdmin as BaseUserAdmin,
@@ -55,3 +55,4 @@ admin.site.register(Service)
 admin.site.register(Position)
 admin.site.register(Business)
 admin.site.register(Review)
+admin.site.register(Invitation)

--- a/beauty/api/models.py
+++ b/beauty/api/models.py
@@ -656,7 +656,6 @@ class Invitation(models.Model):
     email = models.EmailField(
         max_length=100,
         unique=False,
-        validators=(validate_email,),
     )
 
     position = models.ForeignKey(

--- a/beauty/api/models.py
+++ b/beauty/api/models.py
@@ -339,6 +339,7 @@ class Position(models.Model):
     specialist = models.ManyToManyField(
         "CustomUser",
         verbose_name=_("Specialist"),
+        blank=True,
     )
     business = models.ForeignKey(
         "Business",
@@ -631,3 +632,45 @@ class Service(models.Model):
         ordering = ["id"]
         verbose_name = _("Service")
         verbose_name_plural = _("Services")
+
+
+class Invitation(models.Model):
+    """This class represents an invite for a position.
+
+    Attributes:
+        created_at (datetime): represents time of creation, used in token
+        email (str): Email which was used to send an invite
+        position (Position): position in question
+        token (str): token used in confirmations
+    """
+
+    class Meta:
+        """This class ensures that all invites are unique."""
+        unique_together = ["email", "position"]
+
+    created_at = models.DateTimeField(
+        auto_now_add=True,
+        verbose_name=_("Created at"),
+    )
+
+    email = models.EmailField(
+        max_length=100,
+        unique=False,
+        validators=(validate_email,),
+    )
+
+    position = models.ForeignKey(
+        "Position",
+        on_delete=models.CASCADE,
+        verbose_name=_("Position"),
+    )
+
+    token = models.CharField(
+        max_length=64,
+        editable=False,
+        null=True,
+    )
+
+    def __str__(self) -> str:
+        """This method changes representation of the Invite in the admin panel."""
+        return f"Invite for {self.email} on {self.position}"

--- a/beauty/api/serializers/customuser_serializers.py
+++ b/beauty/api/serializers/customuser_serializers.py
@@ -354,3 +354,46 @@ class ResetPasswordSerializer(PasswordsValidation):
             raise serializers.ValidationError(
                 {"password": "Fields should be valid"},
             )
+
+
+class InviteUserCreate(PasswordsValidation, serializers.ModelSerializer):
+    """This serializer is used when user is registered by an invite link."""
+
+    password = serializers.CharField(
+        write_only=True,
+        required=True,
+        style={"input_type": "password", "placeholder": "Password"},
+        validators=[validate_password],
+    )
+    confirm_password = serializers.CharField(
+        write_only=True,
+        required=True,
+        style={"input_type": "password",
+               "placeholder": "Confirmation Password",
+               },
+    )
+
+    class Meta:
+        """Class with a model and model fields for serialization."""
+        model = CustomUser
+        fields = ("id", "first_name", "patronymic", "last_name",
+                  "phone_number", "bio", "avatar",
+                  "password", "confirm_password")
+
+    def create(self, validated_data: dict) -> object:
+        """Create a new user using dict with data.
+
+        Args:
+            validated_data (dict): validated data for new user creation
+
+        Returns:
+            user (object): new user
+
+        """
+        confirm_password = validated_data.pop("confirm_password")
+        validated_data["password"] = make_password(confirm_password)
+
+        logger.info(f"User {validated_data['first_name']} with"
+                    f" {validated_data['email']} was created.")
+
+        return super().create(validated_data)

--- a/beauty/api/serializers/position_serializer.py
+++ b/beauty/api/serializers/position_serializer.py
@@ -6,7 +6,7 @@ import calendar
 from rest_framework import serializers
 from beauty.utils import string_to_time
 from api.serializers.business_serializers import WorkingTimeSerializer
-from api.models import Position, CustomUser
+from api.models import Position
 
 logger = logging.getLogger(__name__)
 
@@ -99,26 +99,3 @@ class PositionSerializer(WorkingTimeSerializer):
 class PositionInviteSerializer(serializers.Serializer):
     """This is a serializer for inviting new specialists to a Position."""
     email = serializers.EmailField()
-
-    def is_valid(self):
-        """Method for validation.
-
-        This method checks whether user exists and validates an email. It also
-        checks that user is not assigned to this position already.
-
-        """
-        email_to_check = self.initial_data["email"]
-        super().is_valid(email_to_check)
-        pos_to_check = self.initial_data["position"]
-        user = CustomUser.objects.filter(email=email_to_check)
-        position = Position.objects.get(pk=pos_to_check)
-
-        if user.exists():
-            if user.get() not in position.specialist.all():
-                return True
-            else:
-                raise serializers.ValidationError(
-                    detail="User is already on the Position.",
-                    code=400,
-                )
-        return False

--- a/beauty/api/tests/test_position_invite.py
+++ b/beauty/api/tests/test_position_invite.py
@@ -1,0 +1,140 @@
+"""This module is for testing position inviting."""
+
+from djoser.utils import encode_uid
+from django.test import TestCase
+from django.core import mail
+from rest_framework.test import APIClient
+from rest_framework.reverse import reverse
+from api.models import Invitation
+from .factories import (CustomUserFactory,
+                        PositionFactory,
+                        GroupFactory)
+
+
+class TestInvitePosition(TestCase):
+    """This class represents a TestCase for inviting users."""
+
+    def setUp(self) -> None:
+        """This method sets up all the needed info for tests."""
+        self.groups = GroupFactory.groups_for_test()
+        self.position = PositionFactory()
+        self.business = self.position.business
+        self.owner = self.position.business.owner
+        self.groups.owner.user_set.add(self.owner)
+        self.specialist = CustomUserFactory()
+        self.groups.specialist.user_set.add(self.specialist)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.owner)
+
+    def test_unauthorized_cant_invite(self):
+        """Unauthorized user can't invite other users."""
+        self.client.force_authenticate(user=None)
+        response = self.client.post(
+            path=reverse("api:position-add-specialist",
+                         kwargs={"pk": self.position.id}),
+            data={"email": self.specialist.email},
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_email_invitation_is_sent(self):
+        """Owner can invite specialists to Position."""
+        response = self.client.post(
+            path=reverse("api:position-add-specialist",
+                         kwargs={"pk": self.position.id}),
+            data={"email": self.specialist.email},
+        )
+        self.invitation = Invitation.objects.first()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.specialist.email, mail.outbox[0].to)
+        self.assertIn(self.position.name, mail.outbox[0].subject)
+        self.assertIn(self.invitation.token, mail.outbox[0].html)
+
+    def test_you_can_only_invite_one_time(self):
+        """Owner can invite specialists to Position only once."""
+        response_first = self.client.post(
+            path=reverse("api:position-add-specialist",
+                         kwargs={"pk": self.position.id}),
+            data={"email": self.specialist.email},
+        )
+        response_second = self.client.post(
+            path=reverse("api:position-add-specialist",
+                         kwargs={"pk": self.position.id}),
+            data={"email": self.specialist.email},
+        )
+        self.assertEqual(response_first.status_code, 200)
+        self.assertEqual(response_second.status_code, 400)
+
+    def test_specialist_can_decline(self):
+        """Specialist can decline invitation."""
+        response_invite = self.client.post(
+            path=reverse("api:position-add-specialist",
+                         kwargs={"pk": self.position.id}),
+            data={"email": self.specialist.email},
+        )
+        self.invitation = Invitation.objects.first()
+        self.id_of_invitation = self.invitation.id
+        response_decline = self.client.get(
+            path=reverse("api:position-approve",
+                         kwargs={
+                             "email": encode_uid(self.invitation.email),
+                             "position": encode_uid(self.invitation.position.id),
+                             "token": self.invitation.token,
+                             "answer": encode_uid("decline"),
+                         },
+                         ),
+        )
+        self.assertEqual(response_invite.status_code, 200)
+        self.assertEqual(response_decline.status_code, 200)
+        self.assertEqual(Invitation.objects.all().count(), 0)
+        self.assertEqual(Invitation.objects.all().count(), 0)
+        self.assertNotEqual(self.specialist, self.position.specialist.all().first())
+
+    def test_specialist_can_approve(self):
+        """Specialist can approve invitation."""
+        response_invite = self.client.post(
+            path=reverse("api:position-add-specialist",
+                         kwargs={"pk": self.position.id}),
+            data={"email": self.specialist.email},
+        )
+        self.invitation = Invitation.objects.first()
+        self.id_of_invitation = self.invitation.id
+        response_decline = self.client.get(
+            path=reverse("api:position-approve",
+                         kwargs={
+                             "email": encode_uid(self.invitation.email),
+                             "position": encode_uid(self.invitation.position.id),
+                             "token": self.invitation.token,
+                             "answer": encode_uid("approve"),
+                         },
+                         ),
+        )
+        self.assertEqual(response_invite.status_code, 200)
+        self.assertEqual(response_decline.status_code, 200)
+        self.assertEqual(Invitation.objects.all().count(), 0)
+        self.assertEqual(self.specialist, self.position.specialist.all().first())
+
+    def test_cant_invite_specialist_if_already_appointed(self):
+        """Owner can't invite to Position, if User is already appointed."""
+        self.position.specialist.set((self.specialist,))
+        response_invite = self.client.post(
+            path=reverse("api:position-add-specialist",
+                         kwargs={"pk": self.position.id}),
+            data={"email": self.specialist.email},
+        )
+        self.assertEqual(response_invite.status_code, 400)
+
+    def test_notregistered_user_is_invited(self):
+        """Owner can invite other users if they are not registered."""
+        email_for_register = "notregistered@gmail.com"
+        response_invite = self.client.post(
+            path=reverse("api:position-add-specialist",
+                         kwargs={"pk": self.position.id}),
+            data={"email": email_for_register},
+        )
+        self.invitation = Invitation.objects.first()
+
+        self.assertEqual(response_invite.status_code, 200)
+        self.assertIn(email_for_register, mail.outbox[0].to)
+        self.assertIn(self.position.name, mail.outbox[0].subject)
+        self.assertIn(self.invitation.token, mail.outbox[0].html)

--- a/beauty/api/urls.py
+++ b/beauty/api/urls.py
@@ -12,6 +12,8 @@ from api.views.review_views import (ReviewDisplayView,
 from api.views.position_views import (InviteSpecialistToPosition,
                                       InviteSpecialistApprove)
 
+from api.views.customuser_views import InviteRegisterView
+
 from .views_api import (AllServicesListCreateView, BusinessesListCreateAPIView,
                         BusinessDetailRUDView, CustomUserDetailRUDView,
                         CustomUserListCreateView, PositionListCreateView, SpecialistDetailView,
@@ -89,6 +91,11 @@ urlpatterns = [
         "position-accept/<str:email>/<str:position>/<str:token>/<str:answer>/",
         InviteSpecialistApprove.as_view(),
         name="position-approve",
+    ),
+    path(
+        "invited/<str:invite>/<str:token>/",
+        InviteRegisterView.as_view(),
+        name="register-invite",
     ),
     path(
         r"<int:user>/reviews/add/",

--- a/beauty/api/urls.py
+++ b/beauty/api/urls.py
@@ -81,12 +81,12 @@ urlpatterns = [
         name="position-detail-list",
     ),
     path(
-        "position/<int:pk>/add",
+        "position/<int:pk>/add/",
         InviteSpecialistToPosition.as_view(),
         name="position-add-specialist",
     ),
     path(
-        "position-accept/<str:user>/<str:position>/<str:token>",
+        "position-accept/<str:email>/<str:position>/<str:token>/<str:answer>/",
         InviteSpecialistApprove.as_view(),
         name="position-approve",
     ),

--- a/beauty/api/urls.py
+++ b/beauty/api/urls.py
@@ -9,6 +9,9 @@ from api.views.review_views import (ReviewDisplayView,
                                     ReviewRUDView,
                                     ReviewAddView)
 
+from api.views.position_views import (InviteSpecialistToPosition,
+                                      InviteSpecialistApprove)
+
 from .views_api import (AllServicesListCreateView, BusinessesListCreateAPIView,
                         BusinessDetailRUDView, CustomUserDetailRUDView,
                         CustomUserListCreateView, PositionListCreateView, SpecialistDetailView,
@@ -76,6 +79,16 @@ urlpatterns = [
         "position/<int:pk>",
         PositionRetrieveUpdateDestroyView.as_view(),
         name="position-detail-list",
+    ),
+    path(
+        "position/<int:pk>/add",
+        InviteSpecialistToPosition.as_view(),
+        name="position-add-specialist",
+    ),
+    path(
+        "position-accept/<str:user>/<str:position>/<str:token>",
+        InviteSpecialistApprove.as_view(),
+        name="position-approve",
     ),
     path(
         r"<int:user>/reviews/add/",

--- a/beauty/api/views/customuser_views.py
+++ b/beauty/api/views/customuser_views.py
@@ -44,6 +44,7 @@ class InviteRegisterView(GenericAPIView):
         serializer = self.get_serializer(data=request.data)
         invitation = Invitation.objects.get(pk=force_str(urlsafe_base64_decode(invite)))
         owner = Position.objects.get(pk=invitation.position.id).business.owner
+        logger.info("Invite link for registering through invite is accessed.")
 
         if SpecialistInviteTokenGenerator().check_token(invitation, token):
             if serializer.is_valid():
@@ -65,6 +66,8 @@ class InviteRegisterView(GenericAPIView):
                         "answer": "accepted",
                     },
                 ).send(to=[owner.email])
+                logger.info(f"{user} (id={user.id}) was created and assigned "
+                            f"for position id {position.id}.")
                 return Response(status=status.HTTP_200_OK)
             else:
                 return Response(
@@ -72,6 +75,7 @@ class InviteRegisterView(GenericAPIView):
                     data={"serializer": "Wrong input data"},
                 )
         else:
+            logger.info("Token is invalid.")
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"token": "Token is invalid"},

--- a/beauty/api/views/customuser_views.py
+++ b/beauty/api/views/customuser_views.py
@@ -1,0 +1,78 @@
+"""This module provides all user's views."""
+
+import logging
+
+from django.contrib.auth.models import Group
+from api.models import Invitation, CustomUser, Position
+from rest_framework.generics import GenericAPIView
+from rest_framework.permissions import AllowAny
+from api.serializers.customuser_serializers import InviteUserCreate
+from django.utils.encoding import force_str
+from django.utils.http import urlsafe_base64_decode
+from rest_framework.response import Response
+from rest_framework import status
+from beauty.tokens import SpecialistInviteTokenGenerator
+from beauty.utils import SpecialistAnswerEmail
+
+
+logger = logging.getLogger(__name__)
+
+
+class InviteRegisterView(GenericAPIView):
+    """This class is used for registration via the invite link.
+
+    Attributes:
+        invitation (Invitation): encoded invitation id
+        token (str): token to check that request is correct
+
+    Returns:
+        HTTP 200: Accepted, token valid.
+        HTTP 400: {"serializer": "Wrong input data"}
+        HTTP 400: {"token": "Token is invalid"}
+
+    """
+
+    serializer_class = InviteUserCreate
+    permission_classes = (AllowAny,)
+
+    def post(self, request, invite, token):
+        """This method is used to register through an invitation.
+
+        After registration, this method makes user a Specialist and assigns
+        the user to a Position in question. Invitation is deleted.
+        """
+        serializer = self.get_serializer(data=request.data)
+        invitation = Invitation.objects.get(pk=force_str(urlsafe_base64_decode(invite)))
+        owner = Position.objects.get(pk=invitation.position.id).business.owner
+
+        if SpecialistInviteTokenGenerator().check_token(invitation, token):
+            if serializer.is_valid():
+                serializer.save(
+                    email=invitation.email,
+                    is_active=True,
+                )
+                user = CustomUser.objects.get(email=invitation.email)
+                specialist_group = Group.objects.get(name="Specialist")
+                specialist_group.user_set.add(user)
+                position = Position.objects.get(pk=invitation.position.id)
+                position.specialist.set((user,))
+                invitation.delete()
+                position.save()
+                SpecialistAnswerEmail(
+                    request=request,
+                    context={
+                        "invite": invitation,
+                        "answer": "accepted",
+                    },
+                ).send(to=[owner.email])
+                return Response(status=status.HTTP_200_OK)
+            else:
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={"serializer": "Wrong input data"},
+                )
+        else:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"token": "Token is invalid"},
+            )

--- a/beauty/api/views/position_views.py
+++ b/beauty/api/views/position_views.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from django.http import Http404
 from django.db import IntegrityError
 from django.contrib.auth.models import Group
 from django.shortcuts import get_object_or_404
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 class InviteSpecialistToPosition(GenericAPIView):
     """This view is used for inviting specialists for a position."""
+
     queryset = Position.objects.all()
     serializer_class = PositionInviteSerializer
     permission_classes = (IsAuthenticated, IsPositionOwner)
@@ -91,7 +93,7 @@ class InviteSpecialistToPosition(GenericAPIView):
                 return True
             else:
                 raise ValidationError({"user": "User is already on the Position."}, code=400)
-        except CustomUser.DoesNotExist:
+        except Http404:
             return False
 
 

--- a/beauty/api/views/position_views.py
+++ b/beauty/api/views/position_views.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from django.db import IntegrityError
 from django.contrib.auth.models import Group
 from django.shortcuts import get_object_or_404
 from rest_framework.generics import GenericAPIView
@@ -9,7 +10,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 from rest_framework import status
 from api.serializers.position_serializer import PositionInviteSerializer
-from api.models import Position, CustomUser
+from api.models import Position, CustomUser, Invitation
 from api.permissions import IsPositionOwner
 from beauty.tokens import SpecialistInviteTokenGenerator
 from rest_framework.permissions import IsAuthenticated
@@ -33,54 +34,58 @@ class InviteSpecialistToPosition(GenericAPIView):
         simply adds an email and sends a request. This request is headed to
         the serializer. Serializer's job is to check whether an email is correct
         (or it will result in a HTTP_400_BAD_REQUEST) and that the user with such
-        an email exists. If user exists, the user will recieve an invite with a
+        email exists. If user exists, the user will recieve an invite with a
         link to confirm an invitation. Otherwise, there will be an email that
         invites to register on a site. There is no way for the owner to know
         if email exists in our database or not.
 
-        Attributes:
-            pk (int): stores an id of the Position in question
-
         Returns:
-            HTTP 200: Email was sent.
-            HTTP 400: User is already on the Position.
-            HTTP 400: Serializaer error, wron email.
+            HTTP 200: All is good, email was sent.
+            HTTP 400: {"user": "User is already on the Position."}
+            HTTP 400: {"email": ["Enter a valid email address."]}
+            HTTP 400: {"error": "User has been already invited"}
 
         """
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         email_to_send = request.data.get("email")
         position_to_invite = self.get_object()
-        context = {
-            "inviter": request.user,
-            "email": email_to_send,
-            "position": position_to_invite,
-        }
 
         logger.info(
             f"{request.user} (id={request.user.id}) is inviting user with email "
             f"'{email_to_send}' to {position_to_invite} (id={position_to_invite.id}).")
 
-        if self.check_user(email_to_send, position_to_invite):
-            logger.info("User exists, sending an invitation for a Position.")
-            PositionAcceptEmail(
-                request=request,
-                context=context,
-            ).send(to=[email_to_send])
-        else:
-            logger.info("User doesn't exist, sending an invitation for registration.")
-            RegisterInviteEmail(
-                request=request,
-                context=context,
-            ).send(to=[email_to_send])
-        return Response(status=status.HTTP_200_OK)
+        try:
+            invite = Invitation(
+                email=email_to_send,
+                position=position_to_invite,
+            )
+            if self.check_user(email_to_send, position_to_invite):
+                invite.save()
+                logger.info("User exists, sending an invitation for a Position.")
+                PositionAcceptEmail(
+                    request=request,
+                    context={"invite": invite},
+                ).send(to=[email_to_send])
+            else:
+                invite.save()
+                logger.info("User doesn't exist, sending an invitation for registration.")
+                RegisterInviteEmail(
+                    request=request,
+                    context={"invite": invite},
+                ).send(to=[email_to_send])
+            return Response(status=status.HTTP_200_OK)
+        except IntegrityError:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"error": "User has been already invited."},
+            )
 
     def check_user(self, user_email, position):
         """This method checks that all requirements are satisfied."""
         try:
             user = get_object_or_404(CustomUser,
                                      email=user_email,
-                                     groups__name="Specialist",
                                      )
             if not user.position_set.filter(id=position.id):
                 return True
@@ -92,35 +97,55 @@ class InviteSpecialistToPosition(GenericAPIView):
 
 class InviteSpecialistApprove(GenericAPIView):
     """This view is used to accept an offer for a Position."""
+
     permission_classes = (IsAuthenticated,)
 
-    def get(self, request, user, position, token):
+    def get(self, request, email, position, token, answer):
         """GET method for accepting an invitation for the Position.
 
         Attributes:
-            user (str): encoded id of the user who is invited
+            email (str): encoded email of the user who is invited
             position (str): encoded id of the position
             token (str): token to check that request is correct
+            answer (str) ["confirm" | "decline"]: answer to the invitation
 
         Returns:
             HTTP 200: Accepted, token valid.
-            HTTP 400: Invalid token.
+            HTTP 400: {"error": "Token is invalid"}
 
         """
-        user_id = force_str(urlsafe_base64_decode(user))
-        position_id = force_str(urlsafe_base64_decode(position))
-        logging.info("Accept Invitation link is accessed. "
-                     f"Info: User ID {user_id} and Position ID {position_id}")
+        try:
+            user_email = force_str(urlsafe_base64_decode(email))
+            position_id = force_str(urlsafe_base64_decode(position))
+            answer = force_str(urlsafe_base64_decode(answer))
+            logging.info("Accept Invitation link is accessed. "
+                         f"Info: User '{user_email}' and Position ID {position_id}")
+            invitation = Invitation.objects.get(
+                email=user_email,
+                position=position_id,
+            )
+            if SpecialistInviteTokenGenerator().check_token(invitation, token):
+                if answer == "decline":
+                    invitation.delete()
+                else:
+                    logger.info("Token is valid.")
+                    user = CustomUser.objects.get(email=user_email)
+                    specialist_group = Group.objects.get(name="Specialist")
+                    specialist_group.user_set.add(user)
+                    position = Position.objects.get(pk=position_id)
+                    position.specialist.set((user,))
+                    invitation.delete()
+                    position.save()
+                return Response(status=status.HTTP_200_OK)
+            else:
+                logger.info("Token is invalid.")
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={"error": "Token is invalid"},
+                )
 
-        if SpecialistInviteTokenGenerator().check_token(request.user, token):
-            logger.info("Token is valid.")
-            user = CustomUser.objects.get(pk=user_id)
-            specialist_group = Group.objects.get(name="Specialist")
-            specialist_group.user_set.add(user)
-            position = Position.objects.get(pk=position_id)
-            position.specialist.set((user,))
-            position.save()
-            return Response(status=status.HTTP_200_OK)
-        else:
-            logger.info("Token is invalid.")
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Invitation.DoesNotExist:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"error": "This link is not valid anymore."},
+            )

--- a/beauty/api/views/position_views.py
+++ b/beauty/api/views/position_views.py
@@ -67,14 +67,13 @@ class InviteSpecialistToPosition(GenericAPIView):
                 request=request,
                 context=context,
             ).send(to=[email_to_send])
-            return Response(status=status.HTTP_200_OK)
         else:
             logger.info("User doesn't exist, sending an invitation for registration.")
             RegisterInviteEmail(
                 request=request,
                 context=context,
             ).send(to=[email_to_send])
-            return Response(status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_200_OK)
 
     def check_user(self, user_email, position):
         """This method checks that all requirements are satisfied."""

--- a/beauty/api/views/position_views.py
+++ b/beauty/api/views/position_views.py
@@ -1,0 +1,107 @@
+"""This module provides all needed position views."""
+
+import logging
+
+from rest_framework.generics import GenericAPIView
+from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
+from rest_framework import status
+from api.serializers.position_serializer import PositionInviteSerializer
+from api.models import Position, CustomUser
+from api.permissions import IsPositionOwner
+from beauty.tokens import SpecialistInviteTokenGenerator
+from rest_framework.permissions import IsAuthenticated
+from beauty.utils import PositionAcceptEmail, RegisterInviteEmail
+from django.utils.encoding import force_str
+from django.utils.http import urlsafe_base64_decode
+
+logger = logging.getLogger(__name__)
+
+
+class InviteSpecialistToPosition(GenericAPIView):
+    """This view is used for inviting specialists for a position."""
+    serializer_class = PositionInviteSerializer
+    permission_classes = (IsAuthenticated & IsPositionOwner)
+
+    def put(self, request, pk, *args, **kwargs):
+        """PUT method for sending invites for a position.
+
+        When business owner wants to add a specialist to a Position, the owner
+        simply adds an email and sends a request. This request is headed to
+        the serializer. Serializer's job is to check whether an email is correct
+        (or it will result in a HTTP_400_BAD_REQUEST) and that the user with such
+        an email exists. If user exists, the user will recieve an invite with a
+        link to confirm an invitation. Otherwise, there will be an email that
+        invites to register on a site. There is no way for the owner to know
+        if email exists in our database or not.
+
+        Attributes:
+            pk (int): stores an id of the Position in question
+
+        Returns:
+            HTTP 200: Email was sent.
+            HTTP 406: User is already on the Position.
+            HTTP 400: Serializaer error, wron email.
+
+        """
+        email_to_send = request.data["email"]
+        position_to_invite = Position.objects.get(pk=pk)
+        context = {
+            "inviter": request.user,
+            "email": email_to_send,
+            "position": pk,
+        }
+        serializer = PositionInviteSerializer(data=context)
+
+        try:
+            logger.info(
+                f"{request.user} (id={request.user.id}) is inviting user with email ",
+                f"'{email_to_send}' to {position_to_invite} (id={position_to_invite.id}).")
+            if serializer.is_valid():
+                logger.info("User exists, sending an invitation for a Position.")
+                PositionAcceptEmail(
+                    request=request,
+                    context=context,
+                ).send(to=[request.data["email"]])
+                return Response(status=status.HTTP_200_OK)
+            else:
+                logger.info("User doesn't exist, sending an invitation for registration.")
+                RegisterInviteEmail(
+                    request=request,
+                    context=context,
+                ).send(to=[request.data["email"]])
+                return Response(status=status.HTTP_200_OK)
+        except ValidationError as err:
+            logger.info(f"Bad request: {err.detail}")
+            if 400 in err.get_codes():
+                return Response(status=status.HTTP_406_NOT_ACCEPTABLE)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+
+class InviteSpecialistApprove(GenericAPIView):
+    """This view is used to accept an offer for a Position."""
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, user, position, token):
+        """GET method for accepting an invitation for the Position.
+
+        Attributes:
+            user (str): encoded id of the user who is invited
+            position (str): encoded id of the position
+            token (str): token to check that request is correct
+
+        Returns:
+            HTTP 200: Accepted, token valid.
+            HTTP 400: Invalid token.
+
+        """
+        user_id = force_str(urlsafe_base64_decode(user))
+        position_id = force_str(urlsafe_base64_decode(position))
+        if SpecialistInviteTokenGenerator().check_token(request.user, token):
+            user = CustomUser.objects.get(pk=user_id)
+            position = Position.objects.get(pk=position_id)
+            position.specialist.set((user,))
+            position.save()
+            return Response(status=status.HTTP_200_OK)
+        else:
+            return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/beauty/beauty/signals.py
+++ b/beauty/beauty/signals.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save
 from django.dispatch import Signal, receiver
 from rest_framework.reverse import reverse
 
-from api.models import Order, Invitation
+from api.models import (Order, Invitation)
 from beauty.tokens import OrderApprovingTokenGenerator, SpecialistInviteTokenGenerator
 from beauty.utils import StatusOrderEmail
 

--- a/beauty/beauty/signals.py
+++ b/beauty/beauty/signals.py
@@ -1,12 +1,13 @@
 """Module with all project signals."""
 
 import logging
+
 from django.db.models.signals import post_save
 from django.dispatch import Signal, receiver
 from rest_framework.reverse import reverse
 
-from api.models import Order
-from beauty.tokens import OrderApprovingTokenGenerator
+from api.models import Order, Invitation
+from beauty.tokens import OrderApprovingTokenGenerator, SpecialistInviteTokenGenerator
 from beauty.utils import StatusOrderEmail
 
 
@@ -20,6 +21,14 @@ def create_token_for_order(sender, instance, created, **kwargs):
     """Create order token."""
     if created:
         instance.token = OrderApprovingTokenGenerator().make_token(instance)
+        instance.save()
+
+
+@receiver(post_save, sender=Invitation, dispatch_uid="")
+def create_token_for_invite(sender, instance, created, **kwargs):
+    """Signal that creates token for an Invitation."""
+    if created:
+        instance.token = SpecialistInviteTokenGenerator().make_token(instance)
         instance.save()
 
 

--- a/beauty/beauty/tokens.py
+++ b/beauty/beauty/tokens.py
@@ -40,6 +40,9 @@ class OrderApprovingTokenGenerator(PasswordResetTokenGenerator):
 class SpecialistInviteTokenGenerator(PasswordResetTokenGenerator):
     """This is a token for approving Position."""
 
-    def _make_hash_value(self, user: object, timestamp: int):
+    def _make_hash_value(self, invitation: object, timestamp: int) -> str:
         """This method sets values for hashing."""
-        return f"{user.id}{timestamp}"
+        created_at_timestamp = invitation.created_at.replace(
+            microsecond=0, tzinfo=None).timestamp()
+
+        return f"{invitation.email}{created_at_timestamp}{timestamp}"

--- a/beauty/beauty/tokens.py
+++ b/beauty/beauty/tokens.py
@@ -35,3 +35,11 @@ class OrderApprovingTokenGenerator(PasswordResetTokenGenerator):
         logger.info(f"Token for {order} was created")
 
         return f"{order.pk}{order.status}{update_at_timestamp}{timestamp}"
+
+
+class SpecialistInviteTokenGenerator(PasswordResetTokenGenerator):
+    """This is a token for approving Position."""
+
+    def _make_hash_value(self, user: object, timestamp: int):
+        """This method sets values for hashing."""
+        return f"{user.id}{timestamp}"

--- a/beauty/beauty/utils.py
+++ b/beauty/beauty/utils.py
@@ -160,3 +160,9 @@ class RegisterInviteEmail(BaseEmailMessage):
     """This email is sent to invite to register on site."""
 
     template_name = "email/register_invite_email.html"
+
+
+class SpecialistAnswerEmail(BaseEmailMessage):
+    """This email is sent to notify owner on the Specialist's decision."""
+
+    template_name = "email/specialist_decision.html"

--- a/beauty/beauty/utils.py
+++ b/beauty/beauty/utils.py
@@ -161,6 +161,26 @@ class RegisterInviteEmail(BaseEmailMessage):
 
     template_name = "email/register_invite_email.html"
 
+    def get_context_data(self):
+        """Get context data for rendering HTML messages."""
+        context = super().get_context_data()
+        context.update(self.create_invite_link(context.get("invite")))
+        return context
+
+    def create_invite_link(self, invite: object):
+        """This method creates invite link."""
+        from djoser.utils import encode_uid
+
+        return {
+            "register_link": reverse(
+                "api:register-invite",
+                kwargs={
+                    "invite": encode_uid(invite.id),
+                    "token": invite.token,
+                },
+                request=None),
+        }
+
 
 class SpecialistAnswerEmail(BaseEmailMessage):
     """This email is sent to notify owner on the Specialist's decision."""

--- a/beauty/beauty/utils.py
+++ b/beauty/beauty/utils.py
@@ -152,7 +152,7 @@ class PositionAcceptEmail(BaseEmailMessage):
         user = CustomUser.objects.get(email=email)
         params = {
             "user": encode_uid(inviter),
-            "position": encode_uid(position),
+            "position": encode_uid(position.id),
             "token": SpecialistInviteTokenGenerator().make_token(user=user),
         }
 

--- a/beauty/templates/email/position_accept_email.html
+++ b/beauty/templates/email/position_accept_email.html
@@ -7,8 +7,6 @@ You have been invited to apply for {{invite.position}}.
 <br>
 <p>Position: {{invite.position}}</p>
 <p>Business: {{invite.position.business}}</p>
-<p>Start time: {{invite.position.start_time}}</p>
-<p>End time: {{invite.position.end_time}}</p>
 <br>
 <a href="{{ protocol }}://{{ domain }}{{ approve_link }}">
     <button type="button" style="color: green;">CONFIRM OFFER</button>

--- a/beauty/templates/email/position_accept_email.html
+++ b/beauty/templates/email/position_accept_email.html
@@ -1,5 +1,5 @@
 {% block subject %}
-You have been invited you to apply for {{invite.position}}.
+You have been invited to apply for {{invite.position}}.
 {% endblock subject %}
 
 {% block html_body %}

--- a/beauty/templates/email/position_accept_email.html
+++ b/beauty/templates/email/position_accept_email.html
@@ -1,11 +1,8 @@
-{% load i18n %}
-
 {% block subject %}
-{% blocktrans %}{{inviter}} is inviting you to apply for {{position}}.{% endblocktrans %}
+{{inviter}} is inviting you to apply for {{position}}.
 {% endblock subject %}
 
 {% block html_body %}
-{% blocktrans %}
 <p>You're receiving this email because you have been invited to apply for the following position:</p>
 <br>
 <p>Position: {{position}}</p>
@@ -18,5 +15,4 @@
 </a>
 <br>
 
-{% endblocktrans %}
 {% endblock html_body %}

--- a/beauty/templates/email/position_accept_email.html
+++ b/beauty/templates/email/position_accept_email.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+
+{% block subject %}
+{% blocktrans %}{{inviter}} is inviting you to apply for {{position}}.{% endblocktrans %}
+{% endblock subject %}
+
+{% block html_body %}
+{% blocktrans %}
+<p>You're receiving this email because you have been invited to apply for the following position:</p>
+<br>
+<p>Position: {{position}}</p>
+<p>Business: {{position.business}}</p>
+<p>Start time: {{position.start_time}}</p>
+<p>End time: {{position.end_time}}</p>
+<br>
+<a href="{{ protocol }}://{{ domain }}{{ approve_link }}">
+    <button type="button" style="color: green;">CONFIRM OFFER</button>
+</a>
+<br>
+
+{% endblocktrans %}
+{% endblock html_body %}

--- a/beauty/templates/email/position_accept_email.html
+++ b/beauty/templates/email/position_accept_email.html
@@ -1,17 +1,21 @@
 {% block subject %}
-{{inviter}} is inviting you to apply for {{position}}.
+You have been invited you to apply for {{invite.position}}.
 {% endblock subject %}
 
 {% block html_body %}
 <p>You're receiving this email because you have been invited to apply for the following position:</p>
 <br>
-<p>Position: {{position}}</p>
-<p>Business: {{position.business}}</p>
-<p>Start time: {{position.start_time}}</p>
-<p>End time: {{position.end_time}}</p>
+<p>Position: {{invite.position}}</p>
+<p>Business: {{invite.position.business}}</p>
+<p>Start time: {{invite.position.start_time}}</p>
+<p>End time: {{invite.position.end_time}}</p>
 <br>
 <a href="{{ protocol }}://{{ domain }}{{ approve_link }}">
     <button type="button" style="color: green;">CONFIRM OFFER</button>
+</a>
+<br>
+<a href="{{ protocol }}://{{ domain }}{{ decline_link }}">
+    <button type="button" style="color: red;">DECLINE OFFER</button>
 </a>
 <br>
 

--- a/beauty/templates/email/register_invite_email.html
+++ b/beauty/templates/email/register_invite_email.html
@@ -1,5 +1,5 @@
 {% block subject %}
-You have been invited you to apply for {{invite.position}}.
+You have been invited to apply for {{invite.position}}.
 {% endblock subject %}
 
 {% block html_body %}

--- a/beauty/templates/email/register_invite_email.html
+++ b/beauty/templates/email/register_invite_email.html
@@ -1,14 +1,14 @@
 {% block subject %}
-{{inviter}} is inviting you to apply for {{position}}.
+You have been invited you to apply for {{invite.position}}.
 {% endblock subject %}
 
 {% block html_body %}
 <p>You're receiving this email because you have been invited to apply for the following position:</p>
 <br>
-<p>Position: {{position}}</p>
-<p>Business: {{position.business}}</p>
-<p>Start time: {{position.start_time}}</p>
-<p>End time: {{position.end_time}}</p>
+<p>Position: {{invite.position}}</p>
+<p>Business: {{invite.position.business}}</p>
+<p>Start time: {{invite.position.start_time}}</p>
+<p>End time: {{invite.position.end_time}}</p>
 <br>
 
 <p>In order to apply for the job, you need to create a new account in our system. </p>

--- a/beauty/templates/email/register_invite_email.html
+++ b/beauty/templates/email/register_invite_email.html
@@ -12,7 +12,7 @@ You have been invited to apply for {{invite.position}}.
 <br>
 
 <p>In order to apply for the job, you need to create a new account in our system. </p>
-<p>For that, please follow the <a href="{{ protocol }}://{{ domain }}">link</a>. </p>
+<p>For that, please follow the <a href="{{ protocol }}://{{ domain }}{{ register_link }}">link</a>. </p>
 
 <br>
 

--- a/beauty/templates/email/register_invite_email.html
+++ b/beauty/templates/email/register_invite_email.html
@@ -7,8 +7,6 @@ You have been invited to apply for {{invite.position}}.
 <br>
 <p>Position: {{invite.position}}</p>
 <p>Business: {{invite.position.business}}</p>
-<p>Start time: {{invite.position.start_time}}</p>
-<p>End time: {{invite.position.end_time}}</p>
 <br>
 
 <p>In order to apply for the job, you need to create a new account in our system. </p>

--- a/beauty/templates/email/register_invite_email.html
+++ b/beauty/templates/email/register_invite_email.html
@@ -1,11 +1,8 @@
-{% load i18n %}
-
 {% block subject %}
-{% blocktrans %}{{inviter}} is inviting you to apply for {{position}}.{% endblocktrans %}
+{{inviter}} is inviting you to apply for {{position}}.
 {% endblock subject %}
 
 {% block html_body %}
-{% blocktrans %}
 <p>You're receiving this email because you have been invited to apply for the following position:</p>
 <br>
 <p>Position: {{position}}</p>
@@ -19,5 +16,4 @@
 
 <br>
 
-{% endblocktrans %}
 {% endblock html_body %}

--- a/beauty/templates/email/register_invite_email.html
+++ b/beauty/templates/email/register_invite_email.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+
+{% block subject %}
+{% blocktrans %}{{inviter}} is inviting you to apply for {{position}}.{% endblocktrans %}
+{% endblock subject %}
+
+{% block html_body %}
+{% blocktrans %}
+<p>You're receiving this email because you have been invited to apply for the following position:</p>
+<br>
+<p>Position: {{position}}</p>
+<p>Business: {{position.business}}</p>
+<p>Start time: {{position.start_time}}</p>
+<p>End time: {{position.end_time}}</p>
+<br>
+
+<p>In order to apply for the job, you need to create a new account in our system. </p>
+<p>For that, please follow the <a href="{{ protocol }}://{{ domain }}">link</a>. </p>
+
+<br>
+
+{% endblocktrans %}
+{% endblock html_body %}

--- a/beauty/templates/email/specialist_decision.html
+++ b/beauty/templates/email/specialist_decision.html
@@ -1,0 +1,14 @@
+{% block subject %}
+Your invitation for {{invite.position}} was {{answer}}.
+{% endblock subject %}
+
+{% block html_body %}
+<p>You're receiving this email because your invitation was {{answer}} for the following position:</p>
+<br>
+<p>Position: {{invite.position}}</p>
+<p>Business: {{invite.position.business}}</p>
+<p>Start time: {{invite.position.start_time}}</p>
+<p>End time: {{invite.position.end_time}}</p>
+<br>
+
+{% endblock html_body %}

--- a/beauty/templates/email/specialist_decision.html
+++ b/beauty/templates/email/specialist_decision.html
@@ -7,8 +7,6 @@ Your invitation for {{invite.position}} was {{answer}}.
 <br>
 <p>Position: {{invite.position}}</p>
 <p>Business: {{invite.position.business}}</p>
-<p>Start time: {{invite.position.start_time}}</p>
-<p>End time: {{invite.position.end_time}}</p>
 <br>
 
 {% endblock html_body %}


### PR DESCRIPTION
Hopefully closes #162 

This adds new model and will require you to migrate.

Owners can send invitation to any email:

a) If User exists, the user receives an invitation (there are 2 links, they can be used only once, token is valid only once, owner can send link only once). 
           *    If user accepts, the user becomes a Specialist (if is not already) and is assigned to the Position.
           *    If user declines, invite is deleted, links are no more valid. Owner is free to send invite again.
           
           *   Owner is notified on the decision by an email.

b) If User doesn't exist, the user receives an invite to register on our site. After registering on site, User becomes a Specialist and is automatically assigned to the Position in question. Owner receives a Confirmation email.

This also fixes our MTM retationship in Position, as it resets it to only one user.

I will be glad to get some suggestion on how I can improve my code, thank you in advance.